### PR TITLE
商品詳細ページの条件分岐修正

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -23,14 +23,14 @@
           %span.shipping_charge
             = @product.shipping_charge.name
       .show__container__item-info__btn
-        - if current_user.id != @product.user_id
-          = button_to '購入画面に進む', {controller: 'products', action: 'index'}, {method: :get, class:'buy-btn'}
-        - else
+        - if user_signed_in? && current_user.id == @product.user_id
           .sellerBtn
             .sellerBtn__edit
               = button_to '商品の編集', {controller: 'products', action: 'edit'}, {method: :get, class:'sellerBtn__edit__btn'}
             .sellerBtn__destroy
               = button_to 'この商品を削除する', {controller: 'products', action: 'destroy'}, {method: :delete, data: {confirm: "この商品を削除しますか？"}, class:'sellerBtn__destroy__btn'}
+        - else
+          = button_to '購入画面に進む', {controller: 'products', action: 'index'}, {method: :get, class:'buy-btn'}
           
       .show__container__item-info__description
         = simple_format @product.description

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -73,12 +73,13 @@
           .right__content__top--a
             .a__myphoto
             .a__name
-              User_name
+              = current_user.nickname
             .a__rank
               %h2.a__rank__level
                 評価 0
               %h2.a__rank__item
-                出品数 0
+                出品数
+                = current_user.products.count
         .right__content__tabs
           %ul.tab__top
             %li.tab__top__li.info


### PR DESCRIPTION
# What
未ログイン状態で詳細ページにアクセスすると購入ボタンが表示されるようにする。

# Why
未ログイン状態での表示が未設定だったため。