### PR TITLE
ページ遷移直後にJavaScriptが発火するよう修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,96 +1,98 @@
 $(function(){
+  $(document).on('turbolinks:load', function() {
   // プルダウンにカテゴリー名を表示しカテゴリーidをサーバーに送信する変数を定義
-  function appendOption(category){
-    var html = `<option value="${category.id}">${category.name}</option>`;
-    return html;
-  }
-  // 子カテゴリーをプルダウンで表示させる変数を定義
-  // 上記の内容をinsertHTMLに入れ、appendChildrenBox(insertHTML)の引数で上記のoptionタグを渡す
-  function appendChildrenBox(insertHTML){
-    var childSelectHtml = "";
-    childSelectHtml = `<div class="category__child" id="children_wrapper">
-                        <select id="child__category" name="product[category_id]" class="select-box">
-                          <option value="">選択してください</option>
-                          ${insertHTML}
-                         </select>
-                        </div>`;
-    // ブラウザに非同期で子セレクトボックスを表示させる
-    $('.sell__container__details__category').append(childSelectHtml);
-  }
-  // 孫カテゴリーをプルダウンで表示させる変数を定義
-  function appendGrandchildrenBox(insertHTML){
-    var grandchildSelectHtml = "";
-    grandchildSelectHtml = `<div class="category__child" id="grandchildren_wrapper">
-                              <select id="grandchild__category" name="product[category_id]" class="select-box">
-                                <option value="">選択してください</option>
-                                ${insertHTML}
-                                </select>
-                            </div>`;
+    function appendOption(category){
+      var html = `<option value="${category.id}">${category.name}</option>`;
+      return html;
+    }
+    // 子カテゴリーをプルダウンで表示させる変数を定義
+    // 上記の内容をinsertHTMLに入れ、appendChildrenBox(insertHTML)の引数で上記のoptionタグを渡す
+    function appendChildrenBox(insertHTML){
+      var childSelectHtml = "";
+      childSelectHtml = `<div class="category__child" id="children_wrapper">
+      <select id="child__category" name="product[category_id]" class="select-box">
+      <option value="">選択してください</option>
+      ${insertHTML}
+      </select>
+      </div>`;
+      // ブラウザに非同期で子セレクトボックスを表示させる
+      $('.sell__container__details__category').append(childSelectHtml);
+    }
+    // 孫カテゴリーをプルダウンで表示させる変数を定義
+    function appendGrandchildrenBox(insertHTML){
+      var grandchildSelectHtml = "";
+      grandchildSelectHtml = `<div class="category__child" id="grandchildren_wrapper">
+                                <select id="grandchild__category" name="product[category_id]" class="select-box">
+                                  <option value="">選択してください</option>
+                                  ${insertHTML}
+                                  </select>
+                              </div>`;
     // ブラウザに非同期で孫セレクトボックスを表示させる
     $('.sell__container__details__category').append(grandchildSelectHtml);
   }
 
-  // 親セレクトボックスでカテゴリーを選択した際にイベントが発火
-  $('#product_category_id').on('change',function(){
-    // 選択したカテゴリーのidを取得し変数定義
-    var parentId = document.getElementById('product_category_id').value;
-    if (parentId != ""){
-      // 取得したカテゴリーのidをparent_idに入れ、JSON用のルートを通ってコントローラーへparent_idを渡し、子カテゴリーのレコードを取得
-      $.ajax({
-        url: '/products/get_category_children/',
-        type: 'GET',
-        data: { parent_id: parentId },
-        dataType: 'json'
-      })
-      // 取得した子カテゴリーのレコードをforEachメソッドで展開
-      .done(function(children){
-        // 親セレクトボックスで再度別のカテゴリーが選択された場合、子、孫のセレクトボックスを消去
+    // 親セレクトボックスでカテゴリーを選択した際にイベントが発火
+    $('#product_category_id').on('change',function(){
+      // 選択したカテゴリーのidを取得し変数定義
+      var parentId = document.getElementById('product_category_id').value;
+      if (parentId != ""){
+        // 取得したカテゴリーのidをparent_idに入れ、JSON用のルートを通ってコントローラーへparent_idを渡し、子カテゴリーのレコードを取得
+        $.ajax({
+          url: '/products/get_category_children/',
+          type: 'GET',
+          data: { parent_id: parentId },
+          dataType: 'json'
+        })
+        // 取得した子カテゴリーのレコードをforEachメソッドで展開
+        .done(function(children){
+          // 親セレクトボックスで再度別のカテゴリーが選択された場合、子、孫のセレクトボックスを消去
+          $('#children_wrapper').remove();
+          $('#grandchildren_wrapper').remove();
+          var insertHTML = '';
+          children.forEach(function(child){
+            // 取得した子レコードを引数で渡し、optionタグにそれぞれidとname（カテゴリー名）をoptionタグに埋め込む
+            insertHTML += appendOption(child);
+          });
+          appendChildrenBox(insertHTML);
+        })
+        .fail(function(){
+          alert('カテゴリー取得に失敗しました');
+        })
+      }else{
         $('#children_wrapper').remove();
         $('#grandchildren_wrapper').remove();
-        var insertHTML = '';
-        children.forEach(function(child){
-          // 取得した子レコードを引数で渡し、optionタグにそれぞれidとname（カテゴリー名）をoptionタグに埋め込む
-          insertHTML += appendOption(child);
-        });
-        appendChildrenBox(insertHTML);
-      })
-      .fail(function(){
-        alert('カテゴリー取得に失敗しました');
-      })
-    }else{
-      $('#children_wrapper').remove();
-      $('#grandchildren_wrapper').remove();
-    }
-  });
-
-  $('.sell__container__details__category').on('change','#child__category',function(){
-    var childId = document.getElementById('child__category').value;
-    if(childId != "" && childId != 1 && childId != 213 && childId != 374 && childId != 521 && childId != 658 && childId != 841 && childId != 960
-    && childId != 1058 && childId != 1176 && childId != 1237 && childId != 1304 && childId != 1449){
-      $.ajax({
-        url: '/products/get_category_grandchildren',
-        type: 'GET',
-        data: { child_id: childId },
-        dataType: 'json'
-      })
-      .done(function(grandchildren){
+      }
+    });
+      
+    $('.sell__container__details__category').on('change','#child__category',function(){
+      var childId = document.getElementById('child__category').value;
+      if(childId != "" && childId != 1 && childId != 213 && childId != 374 && childId != 521 && childId != 658 && childId != 841 && childId != 960
+      && childId != 1058 && childId != 1176 && childId != 1237 && childId != 1304 && childId != 1449){
+        $.ajax({
+          url: '/products/get_category_grandchildren',
+          type: 'GET',
+          data: { child_id: childId },
+          dataType: 'json'
+        })
+        .done(function(grandchildren){
+          $('#grandchildren_wrapper').remove();
+          var insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandchildrenBox(insertHTML);
+        })
+        .fail(function(){
+          alert('カテゴリー取得に失敗しました');
+        })
+      }else{
         $('#grandchildren_wrapper').remove();
-        var insertHTML = '';
-        grandchildren.forEach(function(grandchild){
-          insertHTML += appendOption(grandchild);
-        });
-        appendGrandchildrenBox(insertHTML);
-      })
-      .fail(function(){
-        alert('カテゴリー取得に失敗しました');
-      })
-    }else{
-      $('#grandchildren_wrapper').remove();
-    }
-  })
-  // 商品編集時に親カテゴリが再選択されると子カテゴリ以下が消える
-  $('.edit-parent').on('change',function(){
-    $('.edit-child').remove();
-    $('.edit-grandchild').remove();
-  })
+      }
+    })
+    // 商品編集時に親カテゴリが再選択されると子カテゴリ以下が消える
+    $('.edit-parent').on('change',function(){
+      $('.edit-child').remove();
+      $('.edit-grandchild').remove();
+    })
+  });
 });

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -41,7 +41,7 @@ class ProductsController < ApplicationController
 
   def destroy
     respond_to do |format|
-      if product.destroy
+      if @product.destroy
         format.html{redirect_to root_path, notice:'商品を削除しました'}
       else
         format.html{render action: 'edit', notice:'商品の削除に失敗しました'}
@@ -92,7 +92,7 @@ class ProductsController < ApplicationController
   end
 
   def user_confirm
-    unless current_user.id == @product.user_id?
+    unless current_user.id == @product.user_id
       redirect_to product_path, alert: "この商品を編集する権限がありません"
     end
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all'
-    = javascript_include_tag 'application'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
   
     -# 商品出品完了時のnotice

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,15 +51,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_124200) do
     t.index ["user_id"], name: "index_creditcards_on_user_id"
   end
 
-  create_table "credits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "customer_id", null: false
-    t.string "card_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_credits_on_user_id"
-  end
-
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
     t.datetime "created_at", null: false
@@ -119,7 +110,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_124200) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "creditcards", "users"
-  add_foreign_key "credits", "users"
   add_foreign_key "images", "products"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "users"


### PR DESCRIPTION
# What
商品出品ページと編集ページに遷移した直後でもカテゴリ選択のプルダウンが機能するように
turbolinksを追記する。

# Why
ページ遷移の度にリロードする必要をなくし、ユーザーにとって使いやすくするため。

[![Image from Gyazo](https://i.gyazo.com/21ef1bc3c9d8a77f6692f55975a8e9bc.gif)](https://gyazo.com/21ef1bc3c9d8a77f6692f55975a8e9bc)