### PR TITLE
２重購入をさせない為に購入機能を修正

### DIFF
--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,6 +1,5 @@
 = render "products/header"
 .sell__wrapper
-  .sell__header
   .regist__container
     .sell__container__images
       .user__container__images__titles

--- a/app/views/top/_main.html.haml
+++ b/app/views/top/_main.html.haml
@@ -119,7 +119,7 @@
       ピックアップブランド
     .main__pickupContainer__productBox
       .main__pickupContainer__productBox__head
-        = link_to product_path(id:1) do
+        = link_to "#" do
           %h3.title
             アーカイバ
       .main__pickupContainer__productBox__lists
@@ -128,6 +128,10 @@
             = link_to product_path(product.id) do
               %figure.product__list--img
                 = image_tag product.images[0].image.url
+                -if product.buyer_id.present? 
+                  .product-box_photo__sold
+                    .product-box_photo__sold__inner
+                      SOLD
               .product__list--body
                 %h3.name
                   = product.name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,15 +51,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_124200) do
     t.index ["user_id"], name: "index_creditcards_on_user_id"
   end
 
-  create_table "credits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "customer_id", null: false
-    t.string "card_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_credits_on_user_id"
-  end
-
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
     t.datetime "created_at", null: false
@@ -119,7 +110,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_124200) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "creditcards", "users"
-  add_foreign_key "credits", "users"
   add_foreign_key "images", "products"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "users"


### PR DESCRIPTION
#What
一度購入された商品が再度購入されないように条件分岐を実装

#Why
商品がないものを決済画面に飛ばさないようにするため

https://gyazo.com/4461dca45cb7d2c0c74209755b8fd220
https://gyazo.com/6fe68a0ea25adf2293c772dddd7f6eca